### PR TITLE
Add check to Parse for valid `urn:uuid` prefix and validate version and variant bits

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -5,13 +5,17 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
+	"strings"
 	"time"
 )
 
 var (
-	errInvalidLength = errors.New("invalid length")
-	errInvalidFormat = errors.New("invalid format")
+	errInvalidLength      = errors.New("invalid length")
+	errInvalidFormat      = errors.New("invalid format")
+	errUnsupportedVersion = errors.New("unsupported version")
+	errUnsupportedVariant = errors.New("unsupported variant")
 )
 
 // UUID is a 128 bit (16 byte) value defined by RFC4122.
@@ -121,33 +125,45 @@ func encodeHex(dst []byte, uuid UUID) {
 //	u, err := Parse("56c450b3255d4a2aa761cd1b1bf028e2") // no dashes
 //	u, err := Parse("56c450b3-255d-4a2a-a761-cd1b1bf028e2") // with dashes
 //	u, err := Parse("urn:uuid:56c450b3-255d-4a2a-a761-cd1b1bf028e2") // urn uuid prefix
-func Parse(s string) (uuid UUID, err error) {
+func Parse(s string) (UUID, error) {
 	var x string
 	switch len(s) {
 	case 32: // uuid: "9178e496ba5c4c108b1513a1c70550d0", len: 32
 		x = s[:8] + s[8:13] + s[13:18] + s[18:23] + s[23:]
 	case 36: // uuid: "9178e496-ba5c-4c10-8b15-13a1c70550d0", len: 36
 		if s[8] != '-' || s[13] != '-' || s[18] != '-' || s[23] != '-' {
-			return uuid, errInvalidFormat
+			return UUID{}, errInvalidFormat
 		}
 		x = s[:8] + s[9:13] + s[14:18] + s[19:23] + s[24:]
 	case 45: // uuid: "urn:uuid:9178e496-ba5c-4c10-8b15-13a1c70550d0"
-		if s[17] != '-' || s[22] != '-' || s[27] != '-' || s[32] != '-' {
-			return uuid, errInvalidFormat
+		if !strings.HasPrefix(s, "urn:uuid:") || s[17] != '-' || s[22] != '-' || s[27] != '-' || s[32] != '-' {
+			return UUID{}, errInvalidFormat
 		}
 		x = s[9:17] + s[18:22] + s[23:27] + s[28:32] + s[33:]
 	default:
-		return uuid, errInvalidLength
+		return UUID{}, errInvalidLength
 	}
 
 	b, err := hex.DecodeString(x)
 	if err != nil {
-		return uuid, err
+		return UUID{}, err
 	}
 	if len(b) != 16 {
-		return uuid, errInvalidLength
+		return UUID{}, errInvalidLength
 	}
 
+	switch { // assert version
+	case (b[6] & 0xf0) == 0x40: // version 4
+	case (b[6] & 0xf0) == 0x70: // version 7
+	default:
+		return UUID{}, fmt.Errorf("%v: %d", errUnsupportedVersion, b[6]&0xf0>>4)
+	}
+
+	if (b[8] & 0xc0) != 0x80 { // assert variant
+		return UUID{}, errUnsupportedVariant
+	}
+
+	var uuid UUID
 	copy(uuid[:], b)
 	return uuid, nil
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -16,11 +16,12 @@ func TestParse(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		"with dashes":     {uuid: "53bfe550-4165-4f81-a8e7-c2609579ccc0", want: "53bfe550-4165-4f81-a8e7-c2609579ccc0"},
-		"no dashes":       {uuid: "53bfe55041654f81a8e7c2609579ccc0", want: "53bfe550-4165-4f81-a8e7-c2609579ccc0"},
-		"urn:uuid prefix": {uuid: "urn:uuid:53bfe550-4165-4f81-a8e7-c2609579ccc0", want: "53bfe550-4165-4f81-a8e7-c2609579ccc0"},
-		"uppercase":       {uuid: "53BFE550-4165-4F81-A8E7-C2609579CCC0", want: "53bfe550-4165-4f81-a8e7-c2609579ccc0"},
-		"mixed case":      {uuid: "53bfe550-4165-4f81-A8E7-C2609579CCC0", want: "53bfe550-4165-4f81-a8e7-c2609579ccc0"},
+		"with dashes":        {uuid: "53bfe550-4165-4f81-a8e7-c2609579ccc0", want: "53bfe550-4165-4f81-a8e7-c2609579ccc0"},
+		"no dashes":          {uuid: "53bfe55041654f81a8e7c2609579ccc0", want: "53bfe550-4165-4f81-a8e7-c2609579ccc0"},
+		"urn:uuid prefix":    {uuid: "urn:uuid:53bfe550-4165-4f81-a8e7-c2609579ccc0", want: "53bfe550-4165-4f81-a8e7-c2609579ccc0"},
+		"uppercase":          {uuid: "53BFE550-4165-4F81-A8E7-C2609579CCC0", want: "53bfe550-4165-4f81-a8e7-c2609579ccc0"},
+		"mixed case":         {uuid: "53bfe550-4165-4f81-A8E7-C2609579CCC0", want: "53bfe550-4165-4f81-a8e7-c2609579ccc0"},
+		"invalid urn prefix": {uuid: "abc:1234:53bfe550-4165-4f81-a8e7-c2609579ccc0", want: "00000000-0000-0000-0000-000000000000", wantErr: true},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Check that a `urn:uuid` actually has the corrent prefix. Prevously any 45 length UUID would be parsed (which could be invalid).

Also validate that the version bits are one of the supported versions (4 or 7) and check the variant is RFC4122.

Resolves #3