### PR TITLE
Fill NewV7 from byte 6 instead of 7

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -44,7 +44,7 @@ func NewV4() (UUID, error) {
 	// fill entire uuid with secure, random bytes
 	_, err := io.ReadFull(rand.Reader, uuid[:])
 	if err != nil {
-		return [16]byte{}, err
+		return UUID{}, err
 	}
 
 	// Set version and variant bits
@@ -74,13 +74,13 @@ func NewV7() (UUID, error) {
 	var uuid UUID
 
 	t := time.Now()
-	ms := t.UnixMilli()
+	ms := t.UnixMilli() & ((1 << 48) - 1)               // 48 bit timestamp
 	binary.BigEndian.PutUint64(uuid[:], uint64(ms<<16)) // lower 48 bits. Right 0 padded
 
 	// Fill the rest with random data
-	_, err := io.ReadFull(rand.Reader, uuid[7:])
+	_, err := io.ReadFull(rand.Reader, uuid[6:])
 	if err != nil {
-		return Nil, err
+		return UUID{}, err
 	}
 
 	// Set the version and variant bits

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -101,3 +101,11 @@ func TestUUID_Duplicates(t *testing.T) {
 		})
 	}
 }
+
+func TestPrint(t *testing.T) {
+	u, _ := NewV4()
+	t.Logf("v4: %s %v", u, u[:])
+
+	u, _ = NewV7()
+	t.Logf("v7: %s %v", u, u[:])
+}


### PR DESCRIPTION
I was off by 1 in my head. Bytes 0-5 (len 6) are the timestamp and then bytes 6-15 (len 10) are random data.