### PR TITLE
feat: increase timestamp precision for v7 uuids

### DIFF
--- a/bench/benchmark_test.go
+++ b/bench/benchmark_test.go
@@ -1,0 +1,36 @@
+package bench
+
+import (
+	"testing"
+
+	"github.com/cmackenzie1/go-uuid"
+	guid "github.com/google/uuid"
+)
+
+func BenchmarkNewV4(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		a, _ := uuid.NewV4()
+		_ = a // prevent compiler optimization
+	}
+}
+
+func BenchmarkNewV7(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		a, _ := uuid.NewV7()
+		_ = a // prevent compiler optimization
+	}
+}
+
+func BenchmarkGoogleV4(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		a, _ := guid.NewRandom()
+		_ = a // prevent compiler optimization
+	}
+}
+
+func BenchmarkGoogleV7(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		a, _ := guid.NewV7()
+		_ = a // prevent compiler optimization
+	}
+}

--- a/bench/go.mod
+++ b/bench/go.mod
@@ -1,0 +1,10 @@
+module github.com/cmackenzie1/go-uuid/bench
+
+go 1.19
+
+require (
+	github.com/cmackenzie1/go-uuid v1.1.3
+	github.com/google/uuid v1.6.0
+)
+
+replace github.com/cmackenzie1/go-uuid => ../

--- a/bench/go.sum
+++ b/bench/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -109,10 +109,3 @@ func TestPrint(t *testing.T) {
 	u, _ = NewV7()
 	t.Logf("v7: %s %v", u, u[:])
 }
-
-func BenchmarkNewV4(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		a, _ := NewV4()
-		_ = a // prevent compiler optimization
-	}
-}


### PR DESCRIPTION
Inspired by https://brandur.org/fragments/uuid-v7-monotonicity and the
https://www.rfc-editor.org/rfc/rfc9562.html#monotonicity_counters

Use increased timestamp precision to replace the first 12 bits of `rand_a` field. This helps ensure monotonicity within the same millisecond.

Closes #14 